### PR TITLE
Make `${PREFIX}/bin/nvcc` a symlink so that CMake can use the compiler

### DIFF
--- a/recipe/CMakeLists.txt
+++ b/recipe/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
+
+project(verify_cuda_compiler LANGUAGES CUDA)
+if(NOT DEFINED CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES)
+  message(FATAL_ERROR "CUDA compiler detection failed, no recording of CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES")
+endif()
+add_executable(verify test.cu)

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if [ -z "${CXX+x}" ]; then echo "Please add the C++ compiler to the environment"; exit 1; fi
-
-export NVCC_PREPEND_FLAGS_BACKUP="${NVCC_PREPEND_FLAGS}"
-export NVCC_PREPEND_FLAGS="${NVCC_PREPEND_FLAGS} -ccbin ${CXX}"
+if [[ -n "$CXX" ]]; then
+    export NVCC_PREPEND_FLAGS_BACKUP="${NVCC_PREPEND_FLAGS}"
+    export NVCC_PREPEND_FLAGS="${NVCC_PREPEND_FLAGS} -ccbin=${CXX}"
+fi
+if [ -z "${CXX+x}" ]; then echo 'cuda-nvcc: Please add the `c-compiler` and `cxx-compiler` packages to the environment.'; fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,26 +11,38 @@ for i in `ls`; do
     [[ $i == "build_env_setup.sh" ]] && continue
     [[ $i == "conda_build.sh" ]] && continue
     [[ $i == "metadata_conda_debug.yaml" ]] && continue
-    if [[ $i == "lib" ]] || [[ $i == "include" ]]; then
+    if [[ $i == "bin" ]] || [[ $i == "lib" ]] || [[ $i == "include" ]] || [[ $i == "nvvm" ]]; then
         # Headers and libraries are installed to targetsDir
         mkdir -p ${PREFIX}/${targetsDir}
         mkdir -p ${PREFIX}/$i
         cp -rv $i ${PREFIX}/${targetsDir}
-        if [[ $i == "lib" ]]; then
+        if [[ $i == "bin" ]]; then
+            # Use a custom nvcc.profile to handle the fact that nvcc is a symlink.
+            cp ${RECIPE_DIR}/nvcc.profile.for_prefix_bin ${PREFIX}/bin/nvcc.profile
+            ln -sv ${PREFIX}/${targetsDir}/bin/nvcc ${PREFIX}/bin/nvcc
+            ln -sv ${PREFIX}/${targetsDir}/bin/crt ${PREFIX}/bin/crt
+        elif [[ $i == "lib" ]]; then
             for j in "$i"/*.a*; do
-                # Shared and static libraries are symlinked in $PREFIX/lib
-                ln -sv ../${targetsDir}/$j ${PREFIX}/$j
+                # Static libraries are symlinked in $PREFIX/lib
+                ln -sv ${PREFIX}/${targetsDir}/$j ${PREFIX}/$j
+            done
+            ln -sv ${PREFIX}/${targetsDir}/lib ${PREFIX}/${targetsDir}/lib64
+        elif [[ $i == "nvvm" ]]; then
+            for j in "$i"/*; do
+                ln -sv ${PREFIX}/${targetsDir}/$j ${PREFIX}/$j
             done
         fi
     else
-        cp -r $i ${PREFIX}
+        cp -rv $i ${PREFIX}/${targetsDir}
     fi
 done
 
 # Copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.
 # This will allow them to be run on environment activation.
+# Name this script starting with `~` so it is run after all other compiler activation scripts.
+# At the point of running this, $CXX must be defined.
 for CHANGE in "activate" "deactivate"
 do
     mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
-    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
+    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/~${PKG_NAME}_${CHANGE}.sh"
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,8 @@ source:
   sha256: 85c8c643ea2cfa398e1b5ffcd597f5bb3b738526c9e3fb8e39dd909c55345f36  # [aarch64]
   sha256: f67406f44263f0e4a110a8cf0200bff1d3d0e32917db8a7c9e417a87eb7ca372  # [win]
   patches:
-    - nvcc.profile.patch  # [win]
+    - nvcc.profile.patch      # [linux]
+    - nvcc.profile.patch.win  # [win]
 
 build:
   number: 0
@@ -43,13 +44,16 @@ requirements:
   run_constrained:
     - gcc_impl_{{ target_platform }} >=6,<13  # [linux]
     - arm-variant * {{ arm_variant_type }}  # [aarch64]
+    - cmake >=3.20
 
 test:
   requires:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
+    - ninja
   files:
     - test.cu
+    - CMakeLists.txt
   commands:
     - test -f $PREFIX/targets/{{ target_name }}/lib/libnvptxcompiler_static.a  # [linux]
     - test -f $PREFIX/targets/{{ target_name }}/include/nvPTXCompiler.h        # [linux]
@@ -57,6 +61,7 @@ test:
     - if not exist %LIBRARY_INC%\nvPTXCompiler.h exit 1           # [win]
     - nvcc --version
     - nvcc --verbose test.cu
+    - cmake -S . -B ./build -G=Ninja && cmake --build ./build -v
 
 about:
   home: https://developer.nvidia.com/cuda-toolkit

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ test:
   requires:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
+    - cmake >=3.20
     - ninja
   files:
     - test.cu

--- a/recipe/nvcc.profile.for_prefix_bin
+++ b/recipe/nvcc.profile.for_prefix_bin
@@ -1,0 +1,13 @@
+TOP              = $(_HERE_)/../$(_TARGET_DIR_)/
+
+NVVMIR_LIBRARY_DIR = $(TOP)/$(_NVVM_BRANCH_)/libdevice
+
+LD_LIBRARY_PATH += $(TOP)/lib:
+PATH            += $(TOP)/bin:$(TOP)/$(_NVVM_BRANCH_)/bin:$(_HERE_):
+
+INCLUDES        +=  "-I$(TOP)/include" $(_SPACE_)
+
+LIBRARIES        =+ $(_SPACE_) "-L$(TOP)/lib/stubs" "-L$(TOP)/lib"
+
+CUDAFE_FLAGS    +=
+PTXAS_FLAGS     +=

--- a/recipe/nvcc.profile.patch
+++ b/recipe/nvcc.profile.patch
@@ -1,14 +1,11 @@
---- bin/nvcc.profile	2023-03-23 15:56:49.535384866 -0400
-+++ bin/nvcc.profile.new	2023-03-23 19:21:08.071151138 -0400
-@@ -5,9 +5,9 @@
+--- bin/nvcc.profile
++++ bin/nvcc.profile.new
+@@ -8,7 +8,7 @@ PATH            += $(TOP)/$(_NVVM_BRANCH_)/bin:$(_HERE_):
  
- PATH            += $(TOP)/$(_NVVM_BRANCH_)/bin;$(_HERE_);$(TOP)/lib;
+ INCLUDES        +=  "-I$(TOP)/$(_TARGET_DIR_)/include" $(_SPACE_)
  
--INCLUDES        +=  "-I$(TOP)/include" $(_SPACE_)
-+INCLUDES        +=  "-I$(TOP)/include" $(_SPACE_) "-I$(TOP)/include/targets/$(_WIN_PLATFORM_)" $(_SPACE_)
- 
--LIBRARIES        =+ $(_SPACE_) "/LIBPATH:$(TOP)/lib/$(_WIN_PLATFORM_)"
-+LIBRARIES        =+ $(_SPACE_) "/LIBPATH:$(TOP)/lib/$(_WIN_PLATFORM_)" $(_SPACE_) "/LIBPATH:$(TOP)/lib"
+-LIBRARIES        =+ $(_SPACE_) "-L$(TOP)/$(_TARGET_DIR_)/lib$(_TARGET_SIZE_)/stubs" "-L$(TOP)/$(_TARGET_DIR_)/lib$(_TARGET_SIZE_)"
++LIBRARIES        =+ $(_SPACE_) "-L$(TOP)/$(_TARGET_DIR_)/lib/stubs" "-L$(TOP)/$(_TARGET_DIR_)/lib"
  
  CUDAFE_FLAGS    +=
  PTXAS_FLAGS     +=

--- a/recipe/nvcc.profile.patch.win
+++ b/recipe/nvcc.profile.patch.win
@@ -1,0 +1,14 @@
+--- bin/nvcc.profile	2023-03-23 15:56:49.535384866 -0400
++++ bin/nvcc.profile.new	2023-03-23 19:21:08.071151138 -0400
+@@ -5,9 +5,9 @@
+ 
+ PATH            += $(TOP)/$(_NVVM_BRANCH_)/bin;$(_HERE_);$(TOP)/lib;
+ 
+-INCLUDES        +=  "-I$(TOP)/include" $(_SPACE_)
++INCLUDES        +=  "-I$(TOP)/include" $(_SPACE_) "-I$(TOP)/include/targets/$(_WIN_PLATFORM_)" $(_SPACE_)
+ 
+-LIBRARIES        =+ $(_SPACE_) "/LIBPATH:$(TOP)/lib/$(_WIN_PLATFORM_)"
++LIBRARIES        =+ $(_SPACE_) "/LIBPATH:$(TOP)/lib/$(_WIN_PLATFORM_)" $(_SPACE_) "/LIBPATH:$(TOP)/lib"
+ 
+ CUDAFE_FLAGS    +=
+ PTXAS_FLAGS     +=


### PR DESCRIPTION
CMake scans the verbose output of the compiler and requires a root directory that contains `bin`, `lib`, and `include`.
