### PR TITLE
[WIP] Add includes to compiler flags

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,7 +1,31 @@
 #!/bin/bash
 
-if [[ -n "$CXX" ]]; then
-    export NVCC_PREPEND_FLAGS_BACKUP="${NVCC_PREPEND_FLAGS}"
-    export NVCC_PREPEND_FLAGS="${NVCC_PREPEND_FLAGS} -ccbin=${CXX}"
+export CFLAGS_BACKUP="${CFLAGS}"
+export CPPFLAGS_BACKUP="${CPPFLAGS}"
+export CXXFLAGS_BACKUP="${CXXFLAGS}"
+export NVCC_PREPEND_FLAGS_BACKUP="${NVCC_PREPEND_FLAGS}"
+
+if [ "${CONDA_BUILD:-0}" = "1" ]; then
+    if [ -z "${CXX+x}" ]; then echo 'cuda-nvcc: Please add the `compiler("c")` and `compiler("cxx")` packages to the environment.'; exit 1; fi
+
+    [[ ${target_platform} == "linux-64" ]] && targetsDir="targets/x86_64-linux"
+    [[ ${target_platform} == "linux-ppc64le" ]] && targetsDir="targets/ppc64le-linux"
+    [[ ${target_platform} == "linux-aarch64" ]] && targetsDir="targets/sbsa-linux"
+    CUDA_INCLUDE_DIR="${PREFIX}/${targetsDir}/include"
+
+    # (Leo checking if this is needed): Avoid GCC warnings due to using headers from `BUILD_PREFIX`
+    ln -s "${BUILD_PREFIX}/${targetsDir}/include/crt" "${CUDA_INCLUDE_DIR}"
+
+    export CFLAGS="${CFLAGS} -isystem ${CUDA_INCLUDE_DIR}"
+    export CPPFLAGS="${CPPFLAGS} -isystem ${CUDA_INCLUDE_DIR}"
+    export CXXFLAGS="${CXXFLAGS} -isystem ${CUDA_INCLUDE_DIR}"
+    export NVCC_PREPEND_FLAGS="${NVCC_PREPEND_FLAGS} -ccbin=${CXX} -isystem ${CUDA_INCLUDE_DIR}"
+else
+  # Todo: Either symlink headers to "${PREFIX}/include" in `cuda-nvcc`
+  #       or add logic here to handle `target_platform` outside conda-build
+  CUDA_INCLUDE_DIR="${PREFIX}/include"
+  export CFLAGS="${CFLAGS} -isystem ${CUDA_INCLUDE_DIR}"
+  export CPPFLAGS="${CPPFLAGS} -isystem ${CUDA_INCLUDE_DIR}"
+  export CXXFLAGS="${CXXFLAGS} -isystem ${CUDA_INCLUDE_DIR}"
+  export NVCC_PREPEND_FLAGS="${NVCC_PREPEND_FLAGS} -ccbin=${CXX} -isystem ${CUDA_INCLUDE_DIR}"
 fi
-if [ -z "${CXX+x}" ]; then echo 'cuda-nvcc: Please add the `c-compiler` and `cxx-compiler` packages to the environment.'; fi

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -16,16 +16,16 @@ if [ "${CONDA_BUILD:-0}" = "1" ]; then
     # (Leo checking if this is needed): Avoid GCC warnings due to using headers from `BUILD_PREFIX`
     ln -s "${BUILD_PREFIX}/${targetsDir}/include/crt" "${CUDA_INCLUDE_DIR}"
 
-    export CFLAGS="${CFLAGS} -isystem ${CUDA_INCLUDE_DIR}"
-    export CPPFLAGS="${CPPFLAGS} -isystem ${CUDA_INCLUDE_DIR}"
-    export CXXFLAGS="${CXXFLAGS} -isystem ${CUDA_INCLUDE_DIR}"
-    export NVCC_PREPEND_FLAGS="${NVCC_PREPEND_FLAGS} -ccbin=${CXX} -isystem ${CUDA_INCLUDE_DIR}"
+    export CFLAGS="${CFLAGS} -I${CUDA_INCLUDE_DIR}"
+    export CPPFLAGS="${CPPFLAGS} -I${CUDA_INCLUDE_DIR}"
+    export CXXFLAGS="${CXXFLAGS} -I${CUDA_INCLUDE_DIR}"
+    export NVCC_PREPEND_FLAGS="${NVCC_PREPEND_FLAGS} -ccbin=${CXX} -I${CUDA_INCLUDE_DIR}"
 else
   # Todo: Either symlink headers to "${PREFIX}/include" in `cuda-nvcc`
   #       or add logic here to handle `target_platform` outside conda-build
   CUDA_INCLUDE_DIR="${PREFIX}/include"
-  export CFLAGS="${CFLAGS} -isystem ${CUDA_INCLUDE_DIR}"
-  export CPPFLAGS="${CPPFLAGS} -isystem ${CUDA_INCLUDE_DIR}"
-  export CXXFLAGS="${CXXFLAGS} -isystem ${CUDA_INCLUDE_DIR}"
-  export NVCC_PREPEND_FLAGS="${NVCC_PREPEND_FLAGS} -ccbin=${CXX} -isystem ${CUDA_INCLUDE_DIR}"
+  export CFLAGS="${CFLAGS} -I${CUDA_INCLUDE_DIR}"
+  export CPPFLAGS="${CPPFLAGS} -I${CUDA_INCLUDE_DIR}"
+  export CXXFLAGS="${CXXFLAGS} -I${CUDA_INCLUDE_DIR}"
+  export NVCC_PREPEND_FLAGS="${NVCC_PREPEND_FLAGS} -ccbin=${CXX} -I${CUDA_INCLUDE_DIR}"
 fi

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -6,7 +6,10 @@ export CXXFLAGS_BACKUP="${CXXFLAGS}"
 export NVCC_PREPEND_FLAGS_BACKUP="${NVCC_PREPEND_FLAGS}"
 
 if [ "${CONDA_BUILD:-0}" = "1" ]; then
-    if [ -z "${CXX+x}" ]; then echo 'cuda-nvcc: Please add the `compiler("c")` and `compiler("cxx")` packages to the environment.'; exit 1; fi
+    if [ -z "${CXX+x}" ]; then
+        echo 'cuda-nvcc: Please add the `compiler("c")` and `compiler("cxx")` packages to the environment.'
+        exit 1
+    fi
 
     [[ ${target_platform} == "linux-64" ]] && targetsDir="targets/x86_64-linux"
     [[ ${target_platform} == "linux-ppc64le" ]] && targetsDir="targets/ppc64le-linux"


### PR DESCRIPTION
As the `include` directory is in `targets`, this isn't included in the flags by the compiler normally. Here we update the activation script to add the needed flags to the C, C++, and CUDA compilers.

Todos:

* [ ] Add deactivation logic to remove flags
* [ ] Add `compiler("c")` & `compiler("cxx")` to `cuda-nvcc`'s `requirements/run`
* [ ] Bump `build/number`.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
