### PR TITLE
Require C & C++ compilers in `cuda-nvcc`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 5db25d4fd138013b563f9a3d1d87f7de7df1dac014fd4cccdfbb3435a5cff761
 
 build:
-  number: 6
+  number: 7
   skip: true  # [osx or win]
   skip: true  # [target_platform != "linux-64" and target_platform != cross_target_platform]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,10 +23,9 @@ outputs:
     requirements:
       run:
         - cuda-nvcc_{{ target_platform }} {{ version }}.*
-    test:
-      requires:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+    test:
       commands:
         - test -f $PREFIX/bin/nvcc                          # [linux]
         - if not exist %LIBRARY_BIN%\nvcc.exe exit 1        # [win]


### PR DESCRIPTION
As the `cuda-nvcc` package is intended for usage by developers in their environments and having working C & C++ compilers is a prerequisite, simply make the C & C++ compilers requirements of `cuda-nvcc`.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
