### PR TITLE
Ensure CMake finds CUDA libraries from host packages

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -16,7 +16,7 @@ if [ "${CONDA_BUILD:-0}" = "1" ]; then
     CUDA_LDFLAGS="${CUDA_LDFLAGS} -L${BUILD_PREFIX}/${targetsDir}/lib"
     CUDA_LDFLAGS="${CUDA_LDFLAGS} -L${BUILD_PREFIX}/${targetsDir}/lib/stubs"
     # Needed to fix cross compilation
-    export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_FIND_ROOT_PATH=$PREFIX;$BUILD_PREFIX/$HOST/sysroot;$BUILD_PREFIX/${targetsDir}"
+    export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_FIND_ROOT_PATH=$PREFIX;$BUILD_PREFIX/$HOST/sysroot;$PREFIX/${targetsDir};$BUILD_PREFIX/${targetsDir}"
 else
     CUDA_CFLAGS="${CUDA_CFLAGS} -I${CONDA_PREFIX}/${targetsDir}/include"
     CUDA_LDFLAGS="${CUDA_LDFLAGS} -L${CONDA_PREFIX}/${targetsDir}/lib"

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -15,7 +15,10 @@ if [ "${CONDA_BUILD:-0}" = "1" ]; then
     CUDA_LDFLAGS="${CUDA_LDFLAGS} -L${PREFIX}/${targetsDir}/lib/stubs"
     CUDA_LDFLAGS="${CUDA_LDFLAGS} -L${BUILD_PREFIX}/${targetsDir}/lib"
     CUDA_LDFLAGS="${CUDA_LDFLAGS} -L${BUILD_PREFIX}/${targetsDir}/lib/stubs"
-    # Needed to fix cross compilation
+    # Needed to fix cross compilation.
+    # $PREFIX and $PREFIX/${targetsDir} are needed to properly find all host components
+    # $BUILD_PREFIX/$HOST/sysroot is needed to find compiler bits and is placed before any `targetsDir` for priority.
+    # $BUILD_PREFIX/${targetsDir} is needed for projects that don't enable the CUDA language but use FindCUDAToolkit
     export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_FIND_ROOT_PATH=$PREFIX;$BUILD_PREFIX/$HOST/sysroot;$PREFIX/${targetsDir};$BUILD_PREFIX/${targetsDir}"
 else
     CUDA_CFLAGS="${CUDA_CFLAGS} -I${CONDA_PREFIX}/${targetsDir}/include"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 5db25d4fd138013b563f9a3d1d87f7de7df1dac014fd4cccdfbb3435a5cff761
 
 build:
-  number: 9
+  number: 10
   skip: true  # [osx or win]
   skip: true  # [target_platform != "linux-64" and target_platform != cross_target_platform]
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Consider a conda recipe that looks like:
```
requirements:
  build:
    - {{ compiler('c') }}
    - {{ compiler('cxx') }}
    - {{ compiler('cuda') }}
    - cmake >=3.26.4
    - sysroot_{{ target_platform }} 2.17
    - cuda-version =12.0
  host:
    - libcublas-dev
    - libcublas-static
    - cuda-version =12.0
```

We have placed the CUDA compiler in `build` as the compiler supports cross-compiling. We place the cublas libraries in `host` since it is only for the target platform we are building. Now since the compiler is in `build` it isn't aware of the `host` libraries and doesn't report those locations as implicit search dirs.

So for CMake to find the cublas libraries we need to extend CMAKE_FIND_ROOT_PATH to search `$PREFIX/${targetsDir}`.