### PR TITLE
Relax `sysroot_*`'s `pin_compatible`'s `max_pin`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ outputs:
         - cuda-driver-dev_{{ cross_target_platform }} {{ cuda_version }}.*  # [linux]
         - cuda-nvcc-tools {{ version }}.*
         - cuda-nvcc-impl {{ version }}.*   # [target_platform == cross_target_platform]
-        - {{ pin_compatible("sysroot_" ~ cross_target_platform, max_pin="x.x") }}  # [linux]
+        - {{ pin_compatible("sysroot_" ~ cross_target_platform) }}  # [linux]
     test:
       requires:
         - {{ c_compiler }}_{{ cross_target_platform }} {{ c_compiler_version }}.*      # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 5db25d4fd138013b563f9a3d1d87f7de7df1dac014fd4cccdfbb3435a5cff761
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx]
   skip: true  # [target_platform != "linux-64" and target_platform != cross_target_platform]
 


### PR DESCRIPTION
As we are mainly interested in having the same minimum version for `sysroot_*` and are not concerned with the max version (except that it has the same major version so 2 not 3), drop `sysroot_*`'s `max_pin` from `pin_compatible` to go back to [the `pin_compatible` default of `max_pin="x"`]( https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#extra-jinja2-functions ). This way other `sysroot_*` versions can be used more easily.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
