### PR TITLE
REF: Remove CUDA_TORCH_ARCH_LIST

### DIFF
--- a/.ci_support/linux_64_arm_variant_targetNonecross_target_platformlinux-64.yaml
+++ b/.ci_support/linux_64_arm_variant_targetNonecross_target_platformlinux-64.yaml
@@ -1,7 +1,5 @@
 DEFAULT_CUDAARCHS:
 - 75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtual
-DEFAULT_TORCH_CUDA_ARCH_LIST:
-- 7.5;8.0;8.6;8.9;9.0;10.0;10.3;12.0;12.1+PTX
 arm_variant_target:
 - None
 c_compiler:
@@ -12,8 +10,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -32,6 +28,5 @@ zip_keys:
 - - arm_variant_target
   - cross_target_platform
   - DEFAULT_CUDAARCHS
-  - DEFAULT_TORCH_CUDA_ARCH_LIST
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_arm_variant_targetsbsacross_target_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_64_arm_variant_targetsbsacross_target_platformlinux-aarch64.yaml
@@ -1,7 +1,5 @@
 DEFAULT_CUDAARCHS:
 - 75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtual
-DEFAULT_TORCH_CUDA_ARCH_LIST:
-- 7.5;8.0;8.6;8.9;9.0;10.0;10.3;12.0;12.1+PTX
 arm_variant_target:
 - sbsa
 c_compiler:
@@ -12,8 +10,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -32,6 +28,5 @@ zip_keys:
 - - arm_variant_target
   - cross_target_platform
   - DEFAULT_CUDAARCHS
-  - DEFAULT_TORCH_CUDA_ARCH_LIST
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_arm_variant_targetsbsacross_target_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_arm_variant_targetsbsacross_target_platformlinux-aarch64.yaml
@@ -1,7 +1,5 @@
 DEFAULT_CUDAARCHS:
 - 75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtual
-DEFAULT_TORCH_CUDA_ARCH_LIST:
-- 7.5;8.0;8.6;8.9;9.0;10.0;10.3;12.0;12.1+PTX
 arm_variant_target:
 - sbsa
 c_compiler:
@@ -12,8 +10,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -32,6 +28,5 @@ zip_keys:
 - - arm_variant_target
   - cross_target_platform
   - DEFAULT_CUDAARCHS
-  - DEFAULT_TORCH_CUDA_ARCH_LIST
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,7 +1,5 @@
 DEFAULT_CUDAARCHS:
 - 75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtual
-DEFAULT_TORCH_CUDA_ARCH_LIST:
-- 7.5;8.0;8.6;8.9;9.0;10.0;10.3;12.0;12.1+PTX
 arm_variant_target:
 - None
 c_compiler:
@@ -20,4 +18,3 @@ zip_keys:
 - - arm_variant_target
   - cross_target_platform
   - DEFAULT_CUDAARCHS
-  - DEFAULT_TORCH_CUDA_ARCH_LIST

--- a/README.md
+++ b/README.md
@@ -208,12 +208,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -240,7 +240,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/cuda-nvcc-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -17,8 +17,4 @@ if "%CONDA_BUILD%" == "1" (
         set "CUDAARCHS=@default_cudaarchs@"
         set "CUDAARCHS_BACKUP=UNSET"
     )
-    if not defined TORCH_CUDA_ARCH_LIST (
-        set "TORCH_CUDA_ARCH_LIST=@default_torch_cuda_arch_list@"
-        set "TORCH_CUDA_ARCH_LIST_BACKUP=UNSET"
-    )
 )

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -75,11 +75,6 @@ if [ "${CONDA_BUILD:-0}" = "1" ]; then
         export CUDAARCHS="@default_cudaarchs@"
         export CUDAARCHS_BACKUP="UNSET"
     fi
-    if [[ ! -v TORCH_CUDA_ARCH_LIST ]]
-    then
-        export TORCH_CUDA_ARCH_LIST="@default_torch_cuda_arch_list@"
-        export TORCH_CUDA_ARCH_LIST_BACKUP="UNSET"
-    fi
 
 fi
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,7 +3,6 @@ setlocal enableextensions enabledelayedexpansion
 if errorlevel 1 exit 1
 
 sed -e "s/@default_cudaarchs@/%DEFAULT_CUDAARCHS%/g" ^
-    -e "s/@default_torch_cuda_arch_list@/%DEFAULT_TORCH_CUDA_ARCH_LIST%/g" ^
     %RECIPE_DIR%\activate.bat > %RECIPE_DIR%\activate-replaced.bat
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,7 +10,6 @@ do
     sed -e "s/@cross_target_platform@/$cross_target_platform/g" \
         -e "s/@arm_variant_target@/$arm_variant_target/g" \
         -e "s/@default_cudaarchs@/$DEFAULT_CUDAARCHS/g" \
-        -e "s/@default_torch_cuda_arch_list@/$DEFAULT_TORCH_CUDA_ARCH_LIST/g" \
     "${RECIPE_DIR}/${CHANGE}.sh" > "${PREFIX}/etc/conda/${CHANGE}.d/~cuda-nvcc_${CHANGE}.sh"
 done
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -22,13 +22,8 @@ DEFAULT_CUDAARCHS:
   - "75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtual"
   - "75-real;80-real;86-real;89-real;90a-real;100f-real;103f-real;120a-real;121f-real;121-virtual"  # [linux]
 #  - "72-real;87-real;110"  # [linux]
-DEFAULT_TORCH_CUDA_ARCH_LIST:
-  - "7.5;8.0;8.6;8.9;9.0;10.0;10.3;12.0;12.1+PTX"
-  - "7.5;8.0;8.6;8.9;9.0;10.0;10.3;12.0;12.1+PTX"  # [linux]
-#  - "8.7;11.0+PTX"  # [linux]
 
 zip_keys:
   - arm_variant_target
   - cross_target_platform
   - DEFAULT_CUDAARCHS
-  - DEFAULT_TORCH_CUDA_ARCH_LIST

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -14,8 +14,3 @@ if "%CUDAARCHS_BACKUP%" == "UNSET" (
     set "CUDAARCHS="
     set "CUDAARCHS_BACKUP="
 )
-
-if "%TORCH_CUDA_ARCH_LIST_BACKUP%" == "UNSET" (
-    set "TORCH_CUDA_ARCH_LIST="
-    set "TORCH_CUDA_ARCH_LIST_BACKUP="
-)

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -22,9 +22,3 @@ then
   unset CUDAARCHS
   unset CUDAARCHS_BACKUP
 fi
-
-if [[ "${TORCH_CUDA_ARCH_LIST_BACKUP}" == "UNSET" ]]
-then
-  unset TORCH_CUDA_ARCH_LIST
-  unset TORCH_CUDA_ARCH_LIST_BACKUP
-fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/LICENSE.txt
   sha256: e2c71babfd18a8e69542dd7e9ca018f9caa438094001a58e6bc4d8c999bf0d07
 
-{% set number = 2 %}
+{% set number = 3 %}
 {% if arm_variant_target == "sbsa" %}
 {% set number = number + 100 %}
 {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ build:
   # We need to reference these variables in the recipe or conda-smithy will prune them from
   # the conda_build_config
     - DEFAULT_CUDAARCHS={{ DEFAULT_CUDAARCHS }}
-    - DEFAULT_TORCH_CUDA_ARCH_LIST={{ DEFAULT_TORCH_CUDA_ARCH_LIST }}
 
 requirements:
   build:


### PR DESCRIPTION
The nvcc packages will no longer set TORCH_CUDA_ARCH_LIST in an activation script because pytorch explicitly checks whether the provided archs are valid. This causes the list from new compilers to be incompatible with older versions of pytorch when the list contains very new archs.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
